### PR TITLE
Check if subscriber is still subscribed before calling authenticate.

### DIFF
--- a/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
@@ -112,6 +112,11 @@ import rx.subscriptions.Subscriptions;
       }
     }));
 
+    if (subscriber.isUnsubscribed()) {
+      readerScanning.compareAndSet(true, false);
+      return;
+    }
+
     fingerprintManager.authenticate(new FingerprintManager.CryptoObject(cipher), cancellationSignal,
         0, new FingerprintManager.AuthenticationCallback() {
           @Override public void onAuthenticationError(int errorCode, CharSequence errString) {

--- a/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/FingerprintAuthOnSubscribe.java
@@ -113,7 +113,7 @@ import rx.subscriptions.Subscriptions;
     }));
 
     if (subscriber.isUnsubscribed()) {
-      readerScanning.compareAndSet(true, false);
+      readerScanning.set(false);
       return;
     }
 


### PR DESCRIPTION
Currently, if the subscriber unsubscribes immediately, whorlwind will call fingerprintManager.authenticate() with an already cancelled CancellationSignal, and won't receive the appropriate callback to reset the `readerScanning` boolean.

This just checks the subscription state before making the authenticate call. Note that it's still possible for the subscriber to unsubscribe after this check and before the call to authenticate, but this is a much smaller window and I haven't been able to trigger this case.