### PR TITLE
Split support v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: android
 
 android:
   components:
-    - platform-tools
     - tools
-    - android-23
+    - tools
+    - platform-tools
+    - android-24
     - build-tools-23.0.2
     - extra-android-m2repository
 

--- a/whorlwind-sample/build.gradle
+++ b/whorlwind-sample/build.gradle
@@ -27,12 +27,12 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 23
+  compileSdkVersion 24
   buildToolsVersion "23.0.2"
 
   defaultConfig {
     minSdkVersion 15
-    targetSdkVersion 23
+    targetSdkVersion 24
 
     versionCode 1
     versionName VERSION_NAME

--- a/whorlwind/build.gradle
+++ b/whorlwind/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 23
+  compileSdkVersion 24
   buildToolsVersion '23.0.2'
 
   defaultConfig {
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-v4:23.2.0'
+  compile 'com.android.support:support-compat:24.2.0'
   compile 'com.squareup.okio:okio:1.6.0'
   compile 'io.reactivex:rxjava:1.1.1'
 


### PR DESCRIPTION
Closes #7 uses only support-compat dependency instead of entire support-v4

Also took the liberty to update all dependencies in whorlwind and the sample in the second commit.