### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - tools
     - platform-tools
     - android-24
-    - build-tools-23.0.2
+    - build-tools-24.0.1
     - extra-android-m2repository
 
 jdk:

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 allprojects {
   buildscript {
     repositories {
+      jcenter()
       mavenCentral()
     }
   }
   dependencies {
     repositories {
+      jcenter()
       mavenCentral()
     }
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.11-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/whorlwind-sample/build.gradle
+++ b/whorlwind-sample/build.gradle
@@ -4,9 +4,10 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.5.0'
-    classpath 'me.tatarka:gradle-retrolambda:3.2.4'
+    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'me.tatarka:gradle-retrolambda:3.2.5'
     classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
   }
 
   // The version the android plugin uses doesn't support lambdas. We're bringing a different one.
@@ -15,20 +16,22 @@ buildscript {
 
 apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
+apply plugin: 'com.neenbedankt.android-apt'
 
 dependencies {
   compile project(':whorlwind')
 
-  compile 'io.reactivex:rxjava:1.1.1'
-  compile 'io.reactivex:rxandroid:1.1.0'
-  compile 'com.jakewharton:butterknife:7.0.1'
-  compile 'com.jakewharton.rxbinding:rxbinding:0.1.0'
+  compile 'io.reactivex:rxjava:1.1.9'
+  compile 'io.reactivex:rxandroid:1.2.1'
+  compile 'com.jakewharton:butterknife:8.2.1'
+  apt 'com.jakewharton:butterknife-compiler:8.2.1'
+  compile 'com.jakewharton.rxbinding:rxbinding:0.4.0'
   compile 'com.mattprecious.swirl:swirl:1.0.0'
 }
 
 android {
   compileSdkVersion 24
-  buildToolsVersion "23.0.2"
+  buildToolsVersion "24.0.1"
 
   defaultConfig {
     minSdkVersion 15

--- a/whorlwind-sample/src/main/java/com/squareup/whorlwind/sample/ItemView.java
+++ b/whorlwind-sample/src/main/java/com/squareup/whorlwind/sample/ItemView.java
@@ -5,15 +5,16 @@ import android.util.AttributeSet;
 import android.util.Pair;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import butterknife.Bind;
+
+import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import okio.ByteString;
 import rx.functions.Action1;
 
 public final class ItemView extends LinearLayout {
-  @Bind(R.id.key) TextView keyView;
-  @Bind(R.id.value) TextView valueView;
+  @BindView(R.id.key) TextView keyView;
+  @BindView(R.id.value) TextView valueView;
 
   private Action1<String> readAction;
 

--- a/whorlwind-sample/src/main/java/com/squareup/whorlwind/sample/SampleActivity.java
+++ b/whorlwind-sample/src/main/java/com/squareup/whorlwind/sample/SampleActivity.java
@@ -14,13 +14,15 @@ import android.widget.ListView;
 import android.widget.TextSwitcher;
 import android.widget.TextView;
 import android.widget.Toast;
-import butterknife.Bind;
-import butterknife.ButterKnife;
+
 import com.jakewharton.rxbinding.view.RxView;
 import com.jakewharton.rxbinding.widget.RxTextView;
 import com.mattprecious.swirl.SwirlView;
 import com.squareup.whorlwind.ReadResult;
 import com.squareup.whorlwind.Whorlwind;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import okio.ByteString;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
@@ -32,13 +34,13 @@ import rx.subscriptions.CompositeSubscription;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class SampleActivity extends Activity {
-  @Bind(R.id.content) View contentView;
-  @Bind(R.id.swirl) SwirlView swirlView;
-  @Bind(R.id.message) TextSwitcher messageView;
-  @Bind(R.id.write) View writeView;
-  @Bind(R.id.key) EditText keyView;
-  @Bind(R.id.value) EditText valueView;
-  @Bind(R.id.list) ListView listView;
+  @BindView(R.id.content) View contentView;
+  @BindView(R.id.swirl) SwirlView swirlView;
+  @BindView(R.id.message) TextSwitcher messageView;
+  @BindView(R.id.write) View writeView;
+  @BindView(R.id.key) EditText keyView;
+  @BindView(R.id.value) EditText valueView;
+  @BindView(R.id.list) ListView listView;
 
   private final PublishSubject<String> readSubject = PublishSubject.create();
   private final SampleStorage storage = new SampleStorage();

--- a/whorlwind/build.gradle
+++ b/whorlwind/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.5.0'
+    classpath 'com.android.tools.build:gradle:2.1.3'
   }
 }
 
@@ -8,7 +8,7 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion 24
-  buildToolsVersion '23.0.2'
+  buildToolsVersion '24.0.1'
 
   defaultConfig {
     minSdkVersion 15
@@ -28,8 +28,8 @@ android {
 
 dependencies {
   compile 'com.android.support:support-compat:24.2.0'
-  compile 'com.squareup.okio:okio:1.6.0'
-  compile 'io.reactivex:rxjava:1.1.1'
+  compile 'com.squareup.okio:okio:1.9.0'
+  compile 'io.reactivex:rxjava:1.1.9'
 
   // Test dependencies.
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
As mentioned in #8. Here is the 2nd PR to update a bunch of other dependencies for the library and sample.

As for the jcenter addition it looks like the Android Gradle Plugin v2.1.3 was never pushed to maven central (see: https://mvnrepository.com/artifact/com.android.tools.build/gradle). And once we update build tools to v24 it seems that we also need to update the Gradle Plugin as I'm getting compile errors otherwise.

If you want to stay clear of the addition of jcenter, we can downgrade the Android Gradle Plugin to v2.1.2 which is available from maven central and compiles fine for me.