### PR TITLE
Don't throw for SecurityException

### DIFF
--- a/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/RealWhorlwind.java
@@ -74,7 +74,7 @@ final class RealWhorlwind extends Whorlwind {
   @SuppressLint("MissingPermission") //
   @CheckResult @Override public boolean canStoreSecurely() {
     return checkSelfPermission(USE_FINGERPRINT) == PERMISSION_GRANTED
-        && fingerprintManager.isHardwareDetected()
+        && isHardwareDetected(fingerprintManager)
         && fingerprintManager.hasEnrolledFingerprints();
   }
 

--- a/whorlwind/src/main/java/com/squareup/whorlwind/Whorlwind.java
+++ b/whorlwind/src/main/java/com/squareup/whorlwind/Whorlwind.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Build;
 import android.security.keystore.KeyProperties;
+import android.support.annotation.RequiresApi;
 import android.util.Log;
 import com.squareup.whorlwind.ReadResult.ReadState;
 import io.reactivex.Observable;
@@ -48,6 +49,8 @@ public abstract class Whorlwind {
         return new NullWhorlwind();
       }
 
+      if (!isHardwareDetected(fingerprintManager)) return new NullWhorlwind();
+
       KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
       keyStore.load(null); // Ensure the key store can be loaded before continuing.
 
@@ -62,6 +65,16 @@ public abstract class Whorlwind {
     } catch (Exception e) {
       Log.w(TAG, "Cannot store securely.", e);
       return new NullWhorlwind();
+    }
+  }
+
+  @RequiresApi(Build.VERSION_CODES.M)
+  static boolean isHardwareDetected(FingerprintManager fingerprintManager) {
+    try {
+      return fingerprintManager.isHardwareDetected();
+    } catch (SecurityException e) {
+      Log.w(TAG, "Failed detecting hardware", e);
+      return false;
     }
   }
 


### PR DESCRIPTION
Not  sure why this is happening  but we had this stack trace. Let's avoid throwing here too?

```
java.lang.SecurityException · com.squareup.cash from uid 10151 not allowed to perform USE_FINGERPRINT
Parcel.java:1620android.os.Parcel.readException	
Parcel.java:1573android.os.Parcel.readException	
IFingerprintService.java:385android.hardware.fingerprint.IFingerprintService$Stub$Proxy.isHardwareDetected	
FingerprintManager.java:663android.hardware.fingerprint.FingerprintManager.isHardwareDetected	
RealWhorlwind.java:77com.squareup.whorlwind.RealWhorlwind.canStoreSecurely
```